### PR TITLE
Add workflow to publish standalone executable binary & document how to use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+# Release as workerd binary
+name: Release
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build
+        run: |
+          npx eslint build --bundle --minify src/index.js > dist/worker.js
+          npx wrangler compile config.capnp > dist/hath-exporter
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: hath-exporter
+          path: dist/hath-exporter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           mkdir -p dist
           npx esbuild --bundle --minify src/index.js > dist/worker.js
-          npx wrangler compile config.capnp > dist/hath-exporter
+          npx workerd compile config.capnp > dist/hath-exporter
 
       - name: Upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
 
       - name: Build
         run: |
+          mkdir -p dist
           npx eslint build --bundle --minify src/index.js > dist/worker.js
           npx wrangler compile config.capnp > dist/hath-exporter
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build
         run: |
           mkdir -p dist
-          npx eslint build --bundle --minify src/index.js > dist/worker.js
+          npx esbuild --bundle --minify src/index.js > dist/worker.js
           npx wrangler compile config.capnp > dist/hath-exporter
 
       - name: Upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,5 @@ temp/
 # End of https://www.toptal.com/developers/gitignore/api/node,vscode,intellij+all
 
 .dev.vars
+worker.js
+dist

--- a/config.capnp
+++ b/config.capnp
@@ -1,0 +1,14 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const hathExporterConfig :Workerd.Config = (
+  services = [ (name = "main", worker = .hathExporterWorker) ],
+  sockets = [ ( name = "http", address = "*:8080", http = (), service = "main" ) ]
+);
+
+const hathExporterWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "dist/worker.js")
+  ],
+  compatibilityDate = "2024-04-05",
+  compatibilityFlags = ["nodejs_compat"]
+);


### PR DESCRIPTION
Really useful if you don't want to run it on Cloudflare Workers (in this case due to shared ratelimit).